### PR TITLE
Fixes to use the container name as the queue / topic name, password /…

### DIFF
--- a/src/Connector.SqlServer/AzureServiceBusConnectorProvider.cs
+++ b/src/Connector.SqlServer/AzureServiceBusConnectorProvider.cs
@@ -72,7 +72,7 @@ namespace CluedIn.Connector.AzureServiceBus
                 return Task.FromResult(result.ToDictionary());
             }
 
-            throw new InvalidOperationException($"Unexpected data type for AzureEventConnectorJobData, {jobData.GetType()}");
+            throw new InvalidOperationException($"Unexpected data type for AzureServiceBusConnectorJobData, {jobData.GetType()}");
         }
 
         public override Task<IDictionary<string, object>> GetHelperConfiguration(
@@ -99,7 +99,7 @@ namespace CluedIn.Connector.AzureServiceBus
                     "Wrong CrawlJobData type", nameof(jobData));
             }
 
-            var accountId = $"{result.Name}.{result.ConnectionString}";
+            var accountId = result.Name;
 
             return Task.FromResult(new AccountInformation(accountId, $"{accountId}"));
         }

--- a/src/Connector.SqlServer/AzureServiceBusConstants.cs
+++ b/src/Connector.SqlServer/AzureServiceBusConstants.cs
@@ -43,13 +43,13 @@ namespace CluedIn.Connector.AzureServiceBus
                 {
                     name = KeyName.ConnectionString,
                     displayName = "Connection String",
-                    type = "input",
+                    type = "password",
                     isRequired = true
                 },
                 new Control
                 {
                     name = KeyName.Name,
-                    displayName = "Name",
+                    displayName = "Server Name",
                     type = "input",
                     isRequired = true
                 }

--- a/src/Connector.SqlServer/Connector/AzureServiceBusConnector.cs
+++ b/src/Connector.SqlServer/Connector/AzureServiceBusConnector.cs
@@ -105,7 +105,7 @@ namespace CluedIn.Connector.AzureServiceBus.Connector
 
             await using var client = new ServiceBusClient((string)config.Authentication[AzureServiceBusConstants.KeyName.ConnectionString]);
           
-            ServiceBusSender sender = client.CreateSender((string)config.Authentication[AzureServiceBusConstants.KeyName.Name]);
+            ServiceBusSender sender = client.CreateSender(containerName);
             ServiceBusMessage message = new ServiceBusMessage(JsonUtility.Serialize(data));
 
             try


### PR DESCRIPTION
Fixes to use the container name as the queue/topic name, password / protect the connection string, and do not display the connection string in the account name.

NB, for some consumers the change to use the container name rather than the account name for sending may cause backward compatibility issues. It would be better to use the container name as the queue name so that multiple streams can be used for the same Export Target, e.g. as done with SQL.

I was not able to test this on our environment as it looks like the code is using a newer version of the Cluedin Packages version 3.4.* that we do not have access to, and when testing with version 3.3 we get an error saying the export target does not support streaming modes yet.