### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_EntityFramework>6.0.16</_EntityFramework>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.5.0</_CluedIn>
+    <_EntityFramework>10.0.7</_EntityFramework>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,22 +10,19 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.2.1" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
     <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
-    <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore" version="$(_EntityFramework)" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" version="$(_EntityFramework)" />
-	<PackageReference Update="coverlet.collector" Version="1.2.0" />
-	<PackageReference Update="FluentAssertions" Version="6.11.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="$(_EntityFramework)" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="$(_EntityFramework)" />
+    <PackageReference Update="coverlet.collector" Version="1.2.0" />
+    <PackageReference Update="FluentAssertions" Version="6.11.0" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -33,13 +30,10 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Castle.Windsor" Version="5.1.2" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="4.0.0" />
     <PackageReference Update="CluedIn.DataStore" Version="$(_CluedIn)" />
-    <PackageReference Update="RestSharp" Version="106.10.1" />
     <PackageReference Update="Dapper" Version="2.0.138" />
     <PackageReference Update="Dapper.SqlBuilder" Version="2.0.35" />
     <PackageReference Update="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/Connector.SqlServer/AzureServiceBusConnectorComponent.cs
+++ b/src/Connector.SqlServer/AzureServiceBusConnectorComponent.cs
@@ -92,30 +92,28 @@ namespace CluedIn.Connector.AzureServiceBus
                         }
                     }
 
-                    var streams = streamRepository.GetAllStreams().ToList();
+                    var orgDataStore = ApplicationContext.System.Organization.DataStores.GetDataStore<OrganizationProfile>();
+                    var organizationProfiles = await orgDataStore.SelectAsync(ApplicationContext.System.CreateExecutionContext(), _ => true);
 
-                    var organizationIds = streams.Select(s => s.OrganizationId).Distinct().ToArray();
-
-                    foreach (var orgId in organizationIds)
+                    foreach (var organizationProfile in organizationProfiles)
                     {
-                        var org = new Organization(ApplicationContext, orgId);
+                        var executionContext = ApplicationContext.CreateExecutionContext(organizationProfile.Id);
+                        var streams = await streamRepository.GetAllStreams(executionContext).ToList();
 
-                        foreach (var provider in org.Providers.AllProviderDefinitions.Where(x =>
+                        foreach (var provider in executionContext.Organization.Providers.AllProviderDefinitions.Where(x =>
                                      x.ProviderId == AzureServiceBusConstants.ProviderId))
                         {
                             foreach (var stream in streams.Where(s => s.ConnectorProviderDefinitionId == provider.Id))
                             {
                                 if (stream.Mode != StreamMode.EventStream)
                                 {
-                                    var executionContext = ApplicationContext.CreateExecutionContext(orgId);
-
                                     var model = new SetupConnectorModel
                                     {
                                         ConnectorProviderDefinitionId = provider.Id,
                                         Mode = StreamMode.EventStream,
                                         ContainerName = stream.ContainerName,
                                         DataTypes =
-                                            (await streamRepository.GetStreamMappings(stream.Id))
+                                            (await streamRepository.GetStreamMappings(executionContext, stream.Id))
                                             .Select(x => new DataTypeEntry
                                             {
                                                 Key = x.SourceDataType, Type = x.SourceObjectType
@@ -128,7 +126,7 @@ namespace CluedIn.Connector.AzureServiceBus
 
                                     Log.LogInformation($"[{AzureServiceBusConstants.ConnectorName}] Setting {nameof(StreamMode.EventStream)} for stream '{stream.Name}' ({stream.Id})");
 
-                                    await streamRepository.SetupConnector(stream.Id, model, executionContext);
+                                    await streamRepository.SetupConnector(executionContext, stream.Id, model);
                                 }
                             }
                         }

--- a/test/integration/Connector.AzureServiceBus.Integration.Tests/AutoMockingLazyComponentLoader.cs
+++ b/test/integration/Connector.AzureServiceBus.Integration.Tests/AutoMockingLazyComponentLoader.cs
@@ -4,7 +4,8 @@ using Castle.MicroKernel.Registration;
 using Castle.MicroKernel.Resolvers;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit.Abstractions;
+using Xunit;
+
 
 namespace CluedIn.Connector.AzureServiceBus.Integration.Tests
 {

--- a/test/integration/Connector.AzureServiceBus.Integration.Tests/AzureServiceBusConnectorTests.cs
+++ b/test/integration/Connector.AzureServiceBus.Integration.Tests/AzureServiceBusConnectorTests.cs
@@ -19,7 +19,7 @@ using FluentAssertions;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using Xunit.Abstractions;
+
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.Connector.AzureServiceBus.Integration.Tests

--- a/test/integration/Connector.AzureServiceBus.Integration.Tests/Connector.AzureServiceBus.Integration.Tests.csproj
+++ b/test/integration/Connector.AzureServiceBus.Integration.Tests/Connector.AzureServiceBus.Integration.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>

--- a/test/integration/Connector.AzureServiceBus.Integration.Tests/TestOutputLogger.cs
+++ b/test/integration/Connector.AzureServiceBus.Integration.Tests/TestOutputLogger.cs
@@ -1,7 +1,8 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit.Abstractions;
+using Xunit;
+
 
 namespace CluedIn.Connector.AzureServiceBus.Integration.Tests
 {

--- a/test/unit/Connector.SqlServer.Test/AzureServiceBusConnectorTests.cs
+++ b/test/unit/Connector.SqlServer.Test/AzureServiceBusConnectorTests.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Moq;
 using Xunit;
-using Xunit.Abstractions;
+
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.Connector.AzureServiceBus.Unit.Tests
@@ -40,7 +40,7 @@ namespace CluedIn.Connector.AzureServiceBus.Unit.Tests
         [InlineData("connection1", "container1", "connection1", "container2", 2)]   //    same   connection different container
         [InlineData("connection1", "container1", "connection2", "container1", 2)]   // different connection    same   container
         [InlineData("connection1", "container1", "connection2", "container2", 2)]   // different connection different container
-        public async void BatchesPartitionedByConnectionAndContainer(string connectionString1, string containerName1, string connectionString2, string containerName2, int expectedBatchCount)
+        public async Task BatchesPartitionedByConnectionAndContainer(string connectionString1, string containerName1, string connectionString2, string containerName2, int expectedBatchCount)
         {
             /*
              * arrange
@@ -162,7 +162,7 @@ namespace CluedIn.Connector.AzureServiceBus.Unit.Tests
         }
 
         [Fact]
-        public async void ExceptionOnBatchSendIsRequeuedForEachStoreDataTask()
+        public async Task ExceptionOnBatchSendIsRequeuedForEachStoreDataTask()
         {
             /*
              * arrange

--- a/test/unit/Connector.SqlServer.Test/Connector.AzureServiceBus.Unit.Tests.csproj
+++ b/test/unit/Connector.SqlServer.Test/Connector.AzureServiceBus.Unit.Tests.csproj
@@ -6,7 +6,7 @@
     <None Remove="D:\Projects\CluedIn\CluedIn.Connector.SqlServer\build\assets\nugetlogo.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="CluedIn.DataStore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
@@ -14,7 +14,7 @@
     <PackageReference Include="AutoFixture.Idioms" />
     <PackageReference Include="AutoFixture.AutoMoq" />
     <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
   </ItemGroup>

--- a/test/unit/Connector.SqlServer.Test/TestContext.cs
+++ b/test/unit/Connector.SqlServer.Test/TestContext.cs
@@ -45,8 +45,6 @@ namespace CluedIn.Connector.AzureServiceBus.Unit.Tests
         public readonly Mock<IOrganizationRepository> OrganizationRepository;
           
            
-        public readonly Mock<ISystemVocabularies> SystemVocabularies;
-        
         public readonly Mock<WorkflowRepository> WorkflowRepository;
         public readonly Mock<InMemoryApplicationCache> ApplicationCache;
           
@@ -96,8 +94,6 @@ namespace CluedIn.Connector.AzureServiceBus.Unit.Tests
 
             OrganizationRepository = new Mock<IOrganizationRepository>(MockBehavior.Loose).As<IOrganizationRepository>();
 
-            SystemVocabularies = new Mock<SystemVocabularies>(MockBehavior.Loose, AppContext.Object).As<ISystemVocabularies>();
-
             WorkflowRepository = new Mock<WorkflowRepository>(MockBehavior.Loose, AppContext.Object);
             ApplicationCache = new Mock<InMemoryApplicationCache>(MockBehavior.Loose, Container);
 
@@ -106,7 +102,6 @@ namespace CluedIn.Connector.AzureServiceBus.Unit.Tests
             SystemContext.CallBase = true;
             AppContext.CallBase = true;
             OrganizationRepository.CallBase = true;
-            SystemVocabularies.CallBase = true;
             WorkflowRepository.CallBase = true;
             ApplicationCache.CallBase = true;
 
@@ -160,7 +155,6 @@ namespace CluedIn.Connector.AzureServiceBus.Unit.Tests
             Container.Register(Component.For<IOrganizationRepository>().UsingFactoryMethod(() => proxyGenerator.CreateInterfaceProxyWithTarget(OrganizationRepository.Object)));
             Container.Register(Component.For<IServer>().UsingFactoryMethod(() => proxyGenerator.CreateInterfaceProxyWithTarget(Server.Object)));
             Container.Register(Component.For<IBus>().UsingFactoryMethod(() => proxyGenerator.CreateInterfaceProxyWithTarget(Bus.Object)));
-            Container.Register(Component.For<ISystemVocabularies>().UsingFactoryMethod(() => SystemVocabularies.Object));
             Container.Register(Component.For<WorkflowRepository>().UsingFactoryMethod(() => WorkflowRepository.Object));
             Container.Register(Component.For<IApplicationCache>().UsingFactoryMethod(() => ApplicationCache.Object));
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- xunit migrated from v2 to `xunit.v3 3.2.2`; `AutoFixture.Xunit2` → `AutoFixture.Xunit3 5.0.0-preview0012`